### PR TITLE
samples: zephyr: mcumin: Modify pm_static.yml for nrf54l15

### DIFF
--- a/samples/zephyr/mcumin/smp_svr/pm_static.yml
+++ b/samples/zephyr/mcumin/smp_svr/pm_static.yml
@@ -31,7 +31,7 @@ mcuboot_secondary:
   - mcuboot_secondary_pad
   - mcuboot_secondary_app
   region: flash_primary
-  size: 0xb9000
+  size: 0xa5000
   span: *id003
 mcuboot_secondary_pad:
   region: flash_primary
@@ -40,8 +40,4 @@ mcuboot_secondary_pad:
 mcuboot_secondary_app:
   region: flash_primary
   address: 0xc0800
-  size: 0xb8800
-settings_storage:
-  address: 0x179000
-  region: flash_primary
-  size: 0x4000
+  size: 0xa4800


### PR DESCRIPTION
Attempt to fix building the sample on nrf54l15.
The goal was to make mcuboot build and partitioning scheme was not a focus. As such, partitioning might require further optimization.